### PR TITLE
feat(payment/update): use setupIntent

### DIFF
--- a/test/commands/payment/update.js
+++ b/test/commands/payment/update.js
@@ -25,7 +25,7 @@ test('payment:create', async t => {
         card => card.id === customer.invoice_settings.default_payment_method
       )
 
-      t.is(defaultPaymentMethod.card.exp_year, 2049)
+      t.is(defaultPaymentMethod.card.exp_year, 2048)
 
       t.is(customer.metadata.country, 'US')
       t.is(customer.metadata.ipAddress, '8.8.8.8')
@@ -59,22 +59,19 @@ test('payment:create', async t => {
     })
   ])
 
-  const cardOne = await stripe.customers.createSource(customerId, {
+  const card = await stripe.customers.createSource(customerId, {
     source: tokens[0].id
   })
-  const cardTwo = await stripe.customers.createSource(customerId, {
-    source: tokens[1].id
+
+  const setupIntent = await stripe.setupIntents.create({
+    payment_method: card.id,
+    customer: customerId,
+    confirm: true
   })
 
-  await Promise.all(
-    [cardOne, cardTwo].map(card =>
-      stripe.setupIntents.create({
-        payment_method: card.id,
-        customer: customerId,
-        confirm: true
-      })
-    )
-  )
-
-  await tom.payment.update({ customerId, ipAddress: '8.8.8.8' })
+  await tom.payment.update({
+    setupIntentId: setupIntent.id,
+    customerId,
+    ipAddress: '8.8.8.8'
+  })
 })


### PR DESCRIPTION
Before this change, `payment/update` updates the customer to use the latest card added.

That was in that way until now because we don't have the information to setup the latest payment added, no matter if it was or not a card (for example, if you pay with Link, that isn't a card).

In this PR, it updates the customer payment method to use the ID provided by query parameters.

This is convenient since `stripe.confirmSetup` returns `setup_intent` as part of the redirect URL, so it can be used for the purpose 🙂

