### PR TITLE
fix(stripe): remove old cards

### DIFF
--- a/test/commands/payment/update.js
+++ b/test/commands/payment/update.js
@@ -25,7 +25,7 @@ test('payment:create', async t => {
         card => card.id === customer.invoice_settings.default_payment_method
       )
 
-      t.is(defaultPaymentMethod.card.exp_year, 2048)
+      t.is(defaultPaymentMethod.card.exp_year, 2049)
 
       t.is(customer.metadata.country, 'US')
       t.is(customer.metadata.ipAddress, '8.8.8.8')
@@ -59,12 +59,22 @@ test('payment:create', async t => {
     })
   ])
 
-  const card = await stripe.customers.createSource(customerId, {
-    source: tokens[0].id
+  await stripe.setupIntents.create({
+    payment_method: (
+      await stripe.customers.createSource(customerId, { source: tokens[0].id })
+    ).id,
+    customer: customerId,
+    confirm: true,
+    automatic_payment_methods: {
+      enabled: true,
+      allow_redirects: 'never'
+    }
   })
 
   const setupIntent = await stripe.setupIntents.create({
-    payment_method: card.id,
+    payment_method: (
+      await stripe.customers.createSource(customerId, { source: tokens[1].id })
+    ).id,
     customer: customerId,
     confirm: true,
     automatic_payment_methods: {


### PR DESCRIPTION
When a user sets a new payment method, although it'ts being set as default, pending failyed payment will continue using the old card.

Removing old cards make possible to charge the customer using the latest added.