### PR TITLE
feat(payment): resolve lookup keys to price IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
   },
   "nano-staged": {
     "*.js": [
-      "prettier-standard"
+      "standard --fix"
     ],
     "package.json": [
       "finepack"

--- a/src/commands/payment/session.js
+++ b/src/commands/payment/session.js
@@ -30,12 +30,25 @@ module.exports = ({ config }) => {
 
     const metadata = await getMetadata({ ipAddress, headers })
 
+    const priceId = planId.startsWith('price_')
+      ? planId
+      : await stripe.prices
+        .list({ lookup_keys: [planId], limit: 1 })
+        .then(({ data }) => {
+          if (!data.length) {
+            throw new TypeError(
+                `The lookup key '${planId}' doesn't match any active Stripe price`
+            )
+          }
+          return data[0].id
+        })
+
     const session = await stripe.checkout.sessions.create({
       billing_address_collection: 'required',
       mode: 'subscription',
       line_items: [
         {
-          price: planId,
+          price: priceId,
           quantity: 1
         }
       ],

--- a/test/commands/payment/session.js
+++ b/test/commands/payment/session.js
@@ -47,3 +47,44 @@ test('payment:create has adaptive pricing enabled', async t => {
   const session = await stripe.checkout.sessions.retrieve(sessionId)
   t.is(session.adaptive_pricing.enabled, true)
 })
+
+test('payment:create resolves lookup key to price ID', async t => {
+  const product = await stripe.products.create({ name: 'Test Lookup Key' })
+  const price = await stripe.prices.create({
+    product: product.id,
+    unit_amount: 1000,
+    currency: 'eur',
+    recurring: { interval: 'month' },
+    lookup_key: 'test-lookup-key'
+  })
+
+  const config = createConfig()
+  const tom = createTom(config)
+
+  const { url, sessionId } = await tom.payment.session({
+    planId: 'test-lookup-key',
+    successUrl: 'https://example.com/success',
+    cancelUrl: 'https://example.com/cancel'
+  })
+
+  t.is(typeof url, 'string')
+  t.is(typeof sessionId, 'string')
+
+  await stripe.prices.update(price.id, { active: false })
+  await stripe.products.update(product.id, { active: false })
+})
+
+test('payment:create throws for unknown lookup key', async t => {
+  const config = createConfig()
+  const tom = createTom(config)
+
+  await t.throwsAsync(
+    () =>
+      tom.payment.session({
+        planId: 'nonexistent-key',
+        successUrl: 'https://example.com/success',
+        cancelUrl: 'https://example.com/cancel'
+      }),
+    { instanceOf: TypeError, message: /doesn't match any active Stripe price/ }
+  )
+})


### PR DESCRIPTION
New v4 prices use auto-generated IDs; Stripe doesn't accept lookup keys in line_items[].price directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live payment checkout behavior and adds a Stripe API lookup on each session when planId is not a price ID; misconfiguration or API failures could block checkout for lookup-key plans.
> 
> **Overview**
> **Checkout sessions** now accept either a Stripe `price_…` ID or a **price lookup key** as `planId`. Non-`price_` values are resolved via `stripe.prices.list({ lookup_keys })` before creating the session; missing keys raise a clear `TypeError`. Session metadata still records the original `planId`.
> 
> Pre-commit JS formatting switches from `prettier-standard` to **`standard --fix`** in `nano-staged`.
> 
> Tests cover successful lookup-key checkout and the unknown-key error path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70406a6f4de7d43ca1d46d7ca44adf25c3a138a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->